### PR TITLE
Make Java operators white in Notepad++

### DIFF
--- a/Notepad/Mustard.xml
+++ b/Notepad/Mustard.xml
@@ -131,7 +131,7 @@ License:             GNU Free License.
             <WordsStyle name="NUMBER" styleID="4" fgColor="85E4F6" bgColor="191919" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="STRING" styleID="6" fgColor="B9D5F0" bgColor="191919" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="CHARACTER" styleID="7" fgColor="B9D5F0" bgColor="191919" fontName="" fontStyle="0" fontSize="" />
-            <WordsStyle name="OPERATOR" styleID="10" fgColor="9F9D6D" bgColor="191919" fontName="" fontStyle="1" fontSize="" />
+            <WordsStyle name="OPERATOR" styleID="10" fgColor="FFFFFF" bgColor="191919" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="VERBATIM" styleID="13" fgColor="E08056" bgColor="191919" fontName="" fontStyle="0" fontSize="" />
             <WordsStyle name="REGEX" styleID="14" fgColor="B9D5F0" bgColor="191919" fontName="" fontStyle="1" fontSize="" />
             <WordsStyle name="COMMENT" styleID="1" fgColor="95A78C" bgColor="191919" fontName="" fontStyle="3" fontSize="" />


### PR DESCRIPTION
The operators still match the original Waher-style. Switch operators to white to match Mustard style.